### PR TITLE
Update IR payload storage and create a re-key method for old codes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+#PyCharm config dir
+.idea

--- a/BlackBeanControl.py
+++ b/BlackBeanControl.py
@@ -27,12 +27,12 @@ AlternativeTimeout = ''
 try:
     Options, args = getopt.getopt(sys.argv[1:], 'c:d:r:i:p:m:t:h', ['command=','device=','rekey=','ipaddress=','port=','macaddress=','timeout=','help'])
 except getopt.GetoptError:
-    print('BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout>] [-r <Rekey Command>]')
+    print('BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout>] [-r <Re-key Command>]')
     sys.exit(2)
 
 for Option, Argument in Options:
     if Option in ('-h', '--help'):
-        print('BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout> [-r <Rekey Command>]')
+        print('BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout> [-r <Re-key Command>]')
         sys.exit()
     elif Option in ('-c', '--command'):
         SentCommand = Argument

--- a/BlackBeanControl.py
+++ b/BlackBeanControl.py
@@ -13,6 +13,7 @@ SettingsFile.optionxform = str
 SettingsFile.read(Settings.BlackBeanControlSettings)
 
 SentCommand = ''
+RekeyCommand = False
 DeviceName=''
 DeviceIPAddress = ''
 DevicePort = ''
@@ -24,19 +25,22 @@ AlternativeMACAddress = ''
 AlternativeTimeout = ''
 
 try:
-    Options, args = getopt.getopt(sys.argv[1:], 'c:d:i:p:m:t:h', ['command=','device=','ipaddress=','port=','macaddress=','timeout=','help'])
+    Options, args = getopt.getopt(sys.argv[1:], 'c:d:r:i:p:m:t:h', ['command=','device=','rekey=','ipaddress=','port=','macaddress=','timeout=','help'])
 except getopt.GetoptError:
-    print('BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout>]')
+    print('BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout>] [-r <Rekey Command>]')
     sys.exit(2)
 
 for Option, Argument in Options:
     if Option in ('-h', '--help'):
-        print('BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout>')
+        print('BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout> [-r <Rekey Command>]')
         sys.exit()
     elif Option in ('-c', '--command'):
         SentCommand = Argument
     elif Option in ('-d', '--device'):
         DeviceName = Argument
+    elif Option in ('-r', '--rekey'):
+        RekeyCommand = True
+        SentCommand = Argument
     elif Option in ('-i', '--ipaddress'):
         AlternativeIPAddress = Argument
     elif Option in ('-p', '--port'):
@@ -152,8 +156,25 @@ else:
 RM3Device = broadlink.rm((RealIPAddress, RealPort), RealMACAddress)
 RM3Device.auth()
 
-RM3Key = RM3Device.key
-RM3IV = RM3Device.iv
+if(RekeyCommand):
+    if SettingsFile.has_option('Commands', SentCommand):
+        CommandFromSettings = SettingsFile.get('Commands', SentCommand)
+        RM3Key = RM3Device.key
+        RM3IV = RM3Device.iv
+        DecodedCommand = binascii.unhexlify(CommandFromSettings)
+        AESEncryption = AES.new(str(RM3Key), AES.MODE_CBC, str(RM3IV))
+        EncodedCommand = AESEncryption.encrypt(str(DecodedCommand))
+        FinalCommand = EncodedCommand[0x04:]
+        EncodedCommand = FinalCommand.encode('hex')
+        BlackBeanControlIniFile = open(path.join(Settings.ApplicationDir, 'BlackBeanControl.ini'), 'w')
+        SettingsFile.set('Commands', SentCommand, EncodedCommand)
+        SettingsFile.write(BlackBeanControlIniFile)
+        BlackBeanControlIniFile.close()
+        sys.exit()
+    else:
+        print("Command not found in ini file for re-key.")
+        sys.exit(2)
+
 
 if SettingsFile.has_option('Commands', SentCommand):
     CommandFromSettings = SettingsFile.get('Commands', SentCommand)
@@ -161,13 +182,15 @@ else:
     CommandFromSettings = ''
 
 if CommandFromSettings.strip() != '':
-    DecodedCommand = binascii.unhexlify(CommandFromSettings)
+    #DecodedCommand = binascii.unhexlify(CommandFromSettings)
 
-    AESEncryption = AES.new(str(RM3Key), AES.MODE_CBC, str(RM3IV))
-    EncodedCommand = AESEncryption.encrypt(str(DecodedCommand))
+    #AESEncryption = AES.new(str(RM3Key), AES.MODE_CBC, str(RM3IV))
+    #EncodedCommand = AESEncryption.encrypt(str(DecodedCommand))
     
-    FinalCommand = EncodedCommand[0x04:]    
-    RM3Device.send_data(FinalCommand)
+    #FinalCommand = EncodedCommand[0x04:]
+
+    DecodedCommand = CommandFromSettings.decode('hex')
+    RM3Device.send_data(DecodedCommand)
 else:
     RM3Device.enter_learning()
     time.sleep(RealTimeout)
@@ -177,14 +200,16 @@ else:
         print('Command not received')
         sys.exit()
 
-    AdditionalData = bytearray([0x00, 0x00, 0x00, 0x00])    
-    FinalCommand = AdditionalData + LearnedCommand
+    #AdditionalData = bytearray([0x00, 0x00, 0x00, 0x00])
+    #FinalCommand = AdditionalData + LearnedCommand
 
-    AESEncryption = AES.new(str(RM3Key), AES.MODE_CBC, str(RM3IV))
-    DecodedCommand = binascii.hexlify(AESEncryption.decrypt(str(FinalCommand)))
+    #AESEncryption = AES.new(str(RM3Key), AES.MODE_CBC, str(RM3IV))
+    #DecodedCommand = binascii.hexlify(AESEncryption.decrypt(str(FinalCommand)))
+
+    EncodedCommand = LearnedCommand.encoded('hex')
 
     BlackBeanControlIniFile = open(path.join(Settings.ApplicationDir, 'BlackBeanControl.ini'), 'w')    
-    SettingsFile.set('Commands', SentCommand, DecodedCommand)
+    SettingsFile.set('Commands', SentCommand, EncodedCommand)
     SettingsFile.write(BlackBeanControlIniFile)
     BlackBeanControlIniFile.close()
     

--- a/BlackBeanControl.py
+++ b/BlackBeanControl.py
@@ -156,21 +156,26 @@ else:
 RM3Device = broadlink.rm((RealIPAddress, RealPort), RealMACAddress)
 RM3Device.auth()
 
-if(RekeyCommand):
+if RekeyCommand:
     if SettingsFile.has_option('Commands', SentCommand):
         CommandFromSettings = SettingsFile.get('Commands', SentCommand)
-        RM3Key = RM3Device.key
-        RM3IV = RM3Device.iv
-        DecodedCommand = binascii.unhexlify(CommandFromSettings)
-        AESEncryption = AES.new(str(RM3Key), AES.MODE_CBC, str(RM3IV))
-        EncodedCommand = AESEncryption.encrypt(str(DecodedCommand))
-        FinalCommand = EncodedCommand[0x04:]
-        EncodedCommand = FinalCommand.encode('hex')
-        BlackBeanControlIniFile = open(path.join(Settings.ApplicationDir, 'BlackBeanControl.ini'), 'w')
-        SettingsFile.set('Commands', SentCommand, EncodedCommand)
-        SettingsFile.write(BlackBeanControlIniFile)
-        BlackBeanControlIniFile.close()
-        sys.exit()
+        print CommandFromSettings[0:4]
+        if CommandFromSettings[0:4] != '2600':
+            RM3Key = RM3Device.key
+            RM3IV = RM3Device.iv
+            DecodedCommand = binascii.unhexlify(CommandFromSettings)
+            AESEncryption = AES.new(str(RM3Key), AES.MODE_CBC, str(RM3IV))
+            EncodedCommand = AESEncryption.encrypt(str(DecodedCommand))
+            FinalCommand = EncodedCommand[0x04:]
+            EncodedCommand = FinalCommand.encode('hex')
+            BlackBeanControlIniFile = open(path.join(Settings.ApplicationDir, 'BlackBeanControl.ini'), 'w')
+            SettingsFile.set('Commands', SentCommand, EncodedCommand)
+            SettingsFile.write(BlackBeanControlIniFile)
+            BlackBeanControlIniFile.close()
+            sys.exit()
+        else:
+            print("Command appears to already be re-keyed.")
+            sys.exit(2)
     else:
         print("Command not found in ini file for re-key.")
         sys.exit(2)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Timeout = 30
 
 ### Syntax and usage
 ```
-BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout>]
+BlackBeanControl.py -c <Command name> [-d <Device name>] [-i <IP Address>] [-p <Port>] [-m <MAC Address>] [-t <Timeout>] [-r <Re-key Command>]
 ```
 
 Parameters explanation: 

--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ Parameters explanation:
 - Port - optional parameter. If the script is called with Port parameter, port found in the configuration file will be ignored, and a script will use port from this parameter.
 - MAC Address - optional parameter. If the script is called with MAC address parameter, MAC address found in the configuration file will be ignored, and a script will use MAC address from this parameter.
 - Timeout - optional parameter. If the script is called with Timeout parameter, Timeout found in the configuration file will be ignored, and a script will use Timeout from this parameter.
+- Re-key - optional parameter. This will re-key existing IR data to a new format that does not use the device key for storage. If the data was stored previously with a specific Broadlink device that device name will need to be provided for re-keying by providing a device name via -d.
 
 IP Address, Port, MAC Address and Timeout command line parameters can not be used separately.


### PR DESCRIPTION
- IR payload will now be stored in a raw format instead of using the device provided key with decryption/encryption
- A re-key method was added to convert old style keys to the new raw format so that learning does not have to be performed again.
- Updated the README.md to include information about the re-key command.
- References Issue #9