### PR TITLE
Timeout argument error fix

### DIFF
--- a/BlackBeanControl.py
+++ b/BlackBeanControl.py
@@ -164,7 +164,7 @@ if RealTimeout.strip() == '':
 else:
     RealTimeout = int(RealTimeout.strip())    
 
-RM3Device = broadlink.rm((RealIPAddress, RealPort), RealMACAddress)
+RM3Device = broadlink.rm((RealIPAddress, RealPort), RealMACAddress, RealTimeout)
 RM3Device.auth()
 
 if ReKeyCommand:


### PR DESCRIPTION
Fixes the error
  File "/home/pi/pimatic-app/BlackbeanControl/BlackBeanControl/BlackBeanControl.py", line 167, in <module>
    RM3Device = broadlink.rm((RealIPAddress, RealPort), RealMACAddress)
TypeError: __init__() takes exactly 4 arguments (3 given)